### PR TITLE
fix of switchUrlLang for root url

### DIFF
--- a/src/localize-router.parser.ts
+++ b/src/localize-router.parser.ts
@@ -380,7 +380,7 @@ export abstract class LocalizeParser {
       }
       return trans;
     });
-    const untranslatedRoute = `/${urlParts.join('/')}`;
+    const untranslatedRoute = urlParts.length === 0 ? '' : `/${urlParts.join('/')}`;
     let newTranslatedRoute = this.translateRoute(untranslatedRoute);
     newTranslatedRoute = this.settings.alwaysSetPrefix ? `/${this.urlPrefix}${newTranslatedRoute}` : newTranslatedRoute;
     return newTranslatedRoute;


### PR DESCRIPTION
For root url there was additional '/' character at the end of url e.g. localhost:4200/en/ that caused page not found issue after translation.